### PR TITLE
Improve internal state integrity

### DIFF
--- a/symlink.go
+++ b/symlink.go
@@ -56,6 +56,9 @@ func (sym *Symlink) Link() error {
 		return err
 	}
 
+	sym.Target.Exists = true
+	sym.Target.Link = sym.Source.Path
+
 	return nil
 }
 
@@ -70,6 +73,10 @@ func (sym *Symlink) Unlink() error {
 		}
 		return err
 	}
+
+	sym.Target.Exists = false
+	sym.Target.Link = ""
+
 	return nil
 }
 

--- a/symlink.go
+++ b/symlink.go
@@ -13,43 +13,43 @@ type Symlink struct {
 }
 
 // IsLinked check whether target linked to the given source
-func (l Symlink) IsLinked() bool {
-	return l.Target.Exists && l.Target.Link == l.Source.Path
+func (sym Symlink) IsLinked() bool {
+	return sym.Target.Exists && sym.Target.Link == sym.Source.Path
 }
 
-func (l *Symlink) Read() error {
-	l.read = true
-	if err := l.Source.Read(); err != nil {
+func (sym *Symlink) Read() error {
+	sym.read = true
+	if err := sym.Source.Read(); err != nil {
 		return err
 	}
-	if err := l.Target.Read(); err != nil {
+	if err := sym.Target.Read(); err != nil {
 		return err
 	}
-	return l.Validate()
+	return sym.Validate()
 }
 
 // Validate check whether target linked to the given source
-func (l *Symlink) Validate() error {
-	if !l.read {
-		if err := l.Read(); err != nil {
+func (sym *Symlink) Validate() error {
+	if !sym.read {
+		if err := sym.Read(); err != nil {
 			return err
 		}
 	}
-	if l.Source.Exists && l.Target.Exists && l.Target.Link != l.Source.Path {
+	if sym.Source.Exists && sym.Target.Exists && sym.Target.Link != sym.Source.Path {
 		return ErrTargetMismatch
 	}
 	return nil
 }
 
 // Link creates symlink
-func (l *Symlink) Link() error {
-	if err := l.Validate(); err != nil {
+func (sym *Symlink) Link() error {
+	if err := sym.Validate(); err != nil {
 		if !errors.Is(err, ErrTargetNotExist) {
 			return err
 		}
 	}
 
-	if err := os.Symlink(l.Source.Path, l.Target.Path); err != nil {
+	if err := os.Symlink(sym.Source.Path, sym.Target.Path); err != nil {
 		if errors.Is(err, os.ErrExist) {
 			return ErrTargetExist
 		}
@@ -60,11 +60,11 @@ func (l *Symlink) Link() error {
 }
 
 // Unlink deletes symlink (only target, source file/dir stays)
-func (l *Symlink) Unlink() error {
-	if err := l.Validate(); err != nil {
+func (sym *Symlink) Unlink() error {
+	if err := sym.Validate(); err != nil {
 		return err
 	}
-	if err := os.Remove(l.Target.Path); err != nil {
+	if err := os.Remove(sym.Target.Path); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return ErrTargetNotExist
 		}

--- a/symlink.go
+++ b/symlink.go
@@ -81,8 +81,8 @@ func (sym *Symlink) Unlink() error {
 }
 
 // New returns new Symlink value
-func New(s string, t string) Symlink {
-	return Symlink{
+func New(s string, t string) *Symlink {
+	return &Symlink{
 		Source: NewSource(s),
 		Target: NewTarget(t),
 	}

--- a/symlink_test.go
+++ b/symlink_test.go
@@ -97,3 +97,33 @@ func TestReadWhenTargetSourceMismatch(t *testing.T) {
 	testutil.Diff("target mismatch", err.Error(), t)
 	testutil.Diff(false, sym.IsLinked(), t)
 }
+
+func TestLinkOnSucess(t *testing.T) {
+	source := testutil.FixturePath("home", "dotfiles", "rc")
+	target := testutil.FixturePath("home", ".rc42")
+	sym := symlink.New(source, target)
+
+	err := sym.Link()
+
+	testutil.NoErr(err, t)
+	testutil.Diff(true, sym.Source.Exists, t)
+	testutil.Diff(source, sym.Source.Path, t)
+	testutil.Diff(true, sym.Target.Exists, t)
+	testutil.Diff(target, sym.Target.Path, t)
+	testutil.Diff(true, sym.IsLinked(), t)
+}
+
+func TestUnlinkOnSucess(t *testing.T) {
+	source := testutil.FixturePath("home", "dotfiles", "rc")
+	target := testutil.FixturePath("home", ".rc42")
+	sym := symlink.New(source, target)
+
+	err := sym.Unlink()
+
+	testutil.NoErr(err, t)
+	testutil.Diff(true, sym.Source.Exists, t)
+	testutil.Diff(source, sym.Source.Path, t)
+	testutil.Diff(false, sym.Target.Exists, t)
+	testutil.Diff(target, sym.Target.Path, t)
+	testutil.Diff(false, sym.IsLinked(), t)
+}


### PR DESCRIPTION
What's inside:
* Refactor receivers' arg names for better readability
* Improve internal state integrity after Link and Unlink operations
* Add missing tests for Link and Unlink
* Return struct pointer from New instead of struct value