### PR TITLE
Install ci deps using gobin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ test:
 .PHONY: test
 
 setup-ci:
-	@go get -u github.com/mgechev/revive
-	@go get -u github.com/securego/gosec/v2/cmd/gosec
+	@GO111MODULE=off go get -u github.com/myitcv/gobin
+	@gobin github.com/mgechev/revive
+	@gobin github.com/securego/gosec/v2/cmd/gosec
 
 ci: lint vet sec test


### PR DESCRIPTION
This way should be compatible with all mod-aware go versions: 1.11-1.16